### PR TITLE
Fix crash when initialising doesn't work

### DIFF
--- a/Sources/Battery/Battery.swift
+++ b/Sources/Battery/Battery.swift
@@ -107,7 +107,7 @@ public final class Battery: ObservableObject {
                 .compactMap { [weak self] _ in self?.getState() }
                 .assign(to: &$state)
         } catch {
-            fatalError("Error opening connection, cannot fetch battery details")
+            print("Error opening connection, cannot fetch battery details")
         }
     }
 #endif


### PR DESCRIPTION
We don't want to crash the main app if this dependency can't retrieve battery data.

@pmanot 